### PR TITLE
feat: css樣式,愛心點擊once拿掉

### DIFF
--- a/src/components/CreateTweet.vue
+++ b/src/components/CreateTweet.vue
@@ -119,12 +119,14 @@ export default {
     resize: none;
     border: none;
     margin-top: 10px;
+    overflow-y: hidden;
     &:focus {
       outline: none;
     }
   }
   &__avatar {
     width: 50px;
+    height: 50px;
     border-radius: 50%;
     object-fit: cover;
     margin-right: 10px;

--- a/src/components/MainTitle.vue
+++ b/src/components/MainTitle.vue
@@ -117,12 +117,14 @@ export default {
       resize: none;
       border: none;
       margin-top: 10px;
+      overflow-y:hidden;
       &:focus {
         outline: none;
       }
     }
     &__avatar {
       width: 50px;
+      height: 50px;
       border-radius: 50%;
       object-fit: cover;
       margin-right: 10px;

--- a/src/components/ReplyModal.vue
+++ b/src/components/ReplyModal.vue
@@ -26,16 +26,26 @@
                 class="following-list__avatar"
               />
               <div class="following-item">
-                <span class="following-item__name">{{ initialTweetDetail.TweetAuthor.name }}</span>
-                <span class="following-item__account">@{{ initialTweetDetail.TweetAuthor.account }}</span>
+                <span class="following-item__name">{{
+                  initialTweetDetail.TweetAuthor.name
+                }}</span>
+                <span class="following-item__account"
+                  >@{{ initialTweetDetail.TweetAuthor.account }}</span
+                >
                 <span class="following-item__icon">&#8226;</span>
-                <span class="following-item__date">{{ initialTweetDetail.createdAt | fromNow}}</span>
-                <p class="following-item__description">
-                  {{ initialTweetDetail.description }}
-                </p>
+                <span class="following-item__date">{{
+                  initialTweetDetail.createdAt | fromNow
+                }}</span>
+                <div class="following-item__content">
+                  <p class="following-item__description">
+                    {{ initialTweetDetail.description }}
+                  </p>
+                </div>
                 <div class="following-detail">
                   <span class="following-detail__header">回覆給</span>
-                  <span class="following-detail__account">@{{ initialTweetDetail.TweetAuthor.account }}</span>
+                  <span class="following-detail__account"
+                    >@{{ initialTweetDetail.TweetAuthor.account }}</span
+                  >
                 </div>
               </div>
             </div>
@@ -83,8 +93,8 @@ export default {
   props: {
     initialTweetDetail: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     return {
@@ -93,8 +103,7 @@ export default {
         avatar: "",
         name: "",
       },
-      // tweetDetail: this.initialTweetDetail,
-      comment:'',
+      comment: "",
     };
   },
   mounted() {
@@ -119,7 +128,7 @@ export default {
           tweetId: this.$route.params.id,
           comment: this.comment,
         });
-        console.log(data)
+        console.log(data);
         if (data.status === "error") {
           throw new Error(data.message);
         }
@@ -207,6 +216,10 @@ export default {
   }
   .following-item {
     margin-right: 10px;
+    &__content {
+      width: 100%;
+      overflow-wrap: anywhere;
+    }
     &__name,
     &__description {
       font-size: 15px;

--- a/src/components/TweetDetail.vue
+++ b/src/components/TweetDetail.vue
@@ -26,9 +26,11 @@
         </div>
       </div>
       <div class="following-item">
-        <p class="following-item__description">
-          {{ tweetDetail.description }}
-        </p>
+        <div class="following-item__content">
+          <p class="following-item__description">
+            {{ tweetDetail.description }}
+          </p>
+        </div>
         <span class="following-item__time">{{
           tweetDetail.updatedAt | fromNow
         }}</span>
@@ -58,7 +60,7 @@
         <li
           class="unlike_btn"
           v-show="tweetDetail.isLiked === false"
-          @click.once="likeTweet(tweetDetail.id)"
+          @click="likeTweet(tweetDetail.id)"
         >
           <i class="reply-icon__heart fa-regular fa-heart"></i>
         </li>
@@ -67,7 +69,7 @@
         <li
           class="like_btn"
           v-show="tweetDetail.isLiked === true"
-          @click.once="unlikeTweet(tweetDetail.id)"
+          @click="unlikeTweet(tweetDetail.id)"
         >
           <i class="icon fa-solid fa-heart"></i>
         </li>
@@ -95,7 +97,9 @@
               >@{{ tweetDetail.TweetAuthor.account }}</span
             >
           </div>
-          <p class="reply-item__description">{{ reply.comment }}</p>
+          <div class="reply-item__content">
+            <p class="reply-item__description">{{ reply.comment }}</p>
+          </div>
         </div>
       </div>
     </div>
@@ -136,7 +140,6 @@ export default {
         const response = await tweetsAPI.getTweetDetail({ id });
         this.tweetDetail = response.data;
         this.replies = response.data.Replies;
-        // console.log(response.data);
       } catch (error) {
         console.log(error);
       }
@@ -218,7 +221,7 @@ export default {
 
 .following-content {
   border-top: 1px solid $dividerColor;
-  padding: 15px 75px 0 15px;
+  padding: 15px 15px 0 15px;
 }
 .following-list {
   display: flex;
@@ -251,6 +254,10 @@ export default {
     color: $black;
     padding-top: 20px;
     padding-bottom: 20px;
+  }
+  &__content {
+    width: 100%;
+    overflow-wrap: anywhere;
   }
   &__time,
   &__icon,
@@ -290,14 +297,14 @@ export default {
     margin-right: 150px;
   }
   .like_btn {
-    color: #F91880;
+    color: #f91880;
   }
 }
 
 .reply-list {
   border-bottom: 1px solid $dividerColor;
-  padding: 10px 0 0 15px;
-  height: 105px;
+  padding: 10px 0 15px 15px;
+  min-height: 150px;
   display: flex;
   align-items: flex-start;
   &__avatar {
@@ -311,6 +318,10 @@ export default {
   }
   .reply-item {
     margin-right: 10px;
+    &__content {
+      width: 100%;
+      overflow-wrap: anywhere;
+    }
     &__name {
       margin-right: 5px;
     }

--- a/src/components/Tweets.vue
+++ b/src/components/Tweets.vue
@@ -20,42 +20,44 @@
           <span class="following-item__date">{{
             tweet.createdAt | fromNow
           }}</span>
-          <router-link
-            class="following-item__description"
-            :to="{ name: 'reply-list', params: { id: tweet.id } }"
-          >
-            {{ tweet.description }}
-          </router-link>
-          <div class="following-icons">
-            <div class="icons">
-              <router-link
-                class="icons__comment"
-                :to="{ name: 'reply-list', params: { id: tweet.id } }"
-              >
-                <i class="fa-regular fa-comment"></i>
-              </router-link>
-              <span class="icons__reply-count">{{ tweet.replyCount }}</span>
-            </div>
-            <div class="icons_heart">
-              <div>
-                <li
-                  class="like_btn"
-                  v-show="tweet.isLiked === true"
-                  @click.once="unlikeTweet(tweet.id)"
+          <div class="following-item__content">
+            <router-link
+              class="following-item__description"
+              :to="{ name: 'reply-list', params: { id: tweet.id } }"
+            >
+              {{ tweet.description }}
+            </router-link>
+            <div class="following-icons">
+              <div class="icons">
+                <router-link
+                  class="icons__comment"
+                  :to="{ name: 'reply-list', params: { id: tweet.id } }"
                 >
-                  <i class="icon fa-solid fa-heart"></i>
-                </li>
+                  <i class="fa-regular fa-comment"></i>
+                </router-link>
+                <span class="icons__reply-count">{{ tweet.replyCount }}</span>
               </div>
-              <div>
-                <li
-                  class="unlike_btn"
-                  v-show="tweet.isLiked === false"
-                  @click.once="likeTweet(tweet.id)"
-                >
-                  <i class="icon fa-regular fa-heart"></i>
-                </li>
+              <div class="icons_heart">
+                <div>
+                  <li
+                    class="like_btn"
+                    v-show="tweet.isLiked === true"
+                    @click="unlikeTweet(tweet.id)"
+                  >
+                    <i class="icon fa-solid fa-heart"></i>
+                  </li>
+                </div>
+                <div>
+                  <li
+                    class="unlike_btn"
+                    v-show="tweet.isLiked === false"
+                    @click="likeTweet(tweet.id)"
+                  >
+                    <i class="icon fa-regular fa-heart"></i>
+                  </li>
+                </div>
+                <span class="icons__like-count">{{ tweet.likeCount }}</span>
               </div>
-              <span class="icons__like-count">{{ tweet.likeCount }}</span>
             </div>
           </div>
         </div>
@@ -99,12 +101,15 @@ export default {
           icon: "success",
           title: data.message,
         });
+
+        // await this.fetchTweetsDetail();
       } catch (error) {
         Toast.fire({
           icon: "warning",
           title: error.message,
         });
       }
+
     },
     async unlikeTweet(id) {
       console.log(id);
@@ -148,7 +153,6 @@ export default {
   }
   .following-list {
     padding: 10px 0px 0px 15px;
-    min-height: 146px;
     display: flex;
     align-items: flex-start;
     &__avatar {
@@ -160,15 +164,23 @@ export default {
       margin-right: 10px;
     }
     .following-item {
+      flex: 1;
       margin-right: 10px;
       &__name,
       &__description {
         font-size: 15px;
         color: $black;
-        /* font-weight: bold; */
+      }
+      &__content {
+        width: 100%;
+        padding-right: 15px;
+        overflow-wrap: anywhere;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
       }
       &__description {
-        height: 65px;
+        min-height: 50px;
         margin-top: 5px;
         display: flex;
       }
@@ -180,27 +192,27 @@ export default {
         font-size: 15px;
         color: $mid-gray;
       }
-      .following-icons {
-        font-size: 15px;
-        color: $mid-gray;
-        width: 130px;
-        margin-top: 13px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 30px;
-        .icons {
-          margin-right: 10px;
-          cursor: pointer;
-          &__comment {
-            margin-right: 10px;
-            color: $mid-gray;
-          }
-          &__like-count {
-            margin-left: 10px;
-          }
-        }
-      }
+    }
+  }
+}
+.following-icons {
+  font-size: 15px;
+  color: $mid-gray;
+  width: 130px;
+  margin-top: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 30px;
+  .icons {
+    margin-right: 10px;
+    cursor: pointer;
+    &__comment {
+      margin-right: 10px;
+      color: $mid-gray;
+    }
+    &__like-count {
+      margin-left: 10px;
     }
   }
 }

--- a/src/components/TweetsLikeList.vue
+++ b/src/components/TweetsLikeList.vue
@@ -49,7 +49,7 @@
 
             <ul
               class="tweet_info_icon_like"
-              @click.once="unlikeTweet(like.TweetId)"
+              @click="unlikeTweet(like.TweetId)"
             >
               <li class="like_btn">
                 <i class="fa-solid fa-heart"></i>
@@ -155,7 +155,7 @@ export default {
 
 .tweet {
   border: 1px solid $light-gray;
-  height: 145px;
+  min-height: 145px;
   display: flex;
   &_avatar {
     width: 80px;

--- a/src/components/TweetsList.vue
+++ b/src/components/TweetsList.vue
@@ -183,7 +183,7 @@ export default {
 
 .tweet {
   border: 1px solid $light-gray;
-  height: 145px;
+  min-height: 150px;
   display: flex;
   &_avatar {
     min-width: 80px;

--- a/src/components/TweetsReplyList.vue
+++ b/src/components/TweetsReplyList.vue
@@ -111,7 +111,7 @@ export default {
 
 .tweet {
   border: 1px solid $light-gray;
-  height: 135px;
+  min-height: 140px;
   display: flex;
   &_avatar {
     min-width: 80px;


### PR DESCRIPTION
修正 
main / modal / replyDetail / tweetList / tweetReplyList/ tweetLikeList字數太多跑版

replyList的愛心點擊可以正常切換,
如果將tweetList的once拿掉，點擊愛心後會瘋狂發送請求讓愛心數變成負值..(請求太多導致server掛了)所以我沒改這個檔案
main的頁面則是對貼文點擊愛心後,畫面不會刷新